### PR TITLE
Fix ULID timestamp byte masking

### DIFF
--- a/src/ulid.ts
+++ b/src/ulid.ts
@@ -8,7 +8,7 @@ export const tsToA6 = (ts:number) => {
   else if (ts > MAX_TS) ts = MAX_TS;
   const bytes = new Uint8Array(6);
   for (let i = 5; i >= 0; i--) {
-    bytes[i] = ts & 0xFFFF;
+    bytes[i] = ts & 0xFF;
     ts /= 256;
   }
   return bytes;


### PR DESCRIPTION
## Summary
- correct masking when extracting ULID timestamp bytes

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432d5598508320943a844166acb22c