### PR TITLE
Fix noiseForValue byte extraction

### DIFF
--- a/src/noise.ts
+++ b/src/noise.ts
@@ -221,7 +221,7 @@ export const NoiseValueMax = noiseValue(noiseNeg(zeroNoise()));
 export const noiseForValue = (value:bigint) => {
   const noise = new Uint8Array(NOISE_BYTES);
   for (let i = NOISE_BYTES - 1; i >= 0; i--) {
-    noise[i] = Number(value & 0xffffn);
+    noise[i] = Number(value & 0xffn);
     value >>= 8n;
   }
   return noise as Noise;


### PR DESCRIPTION
## Summary
- fix mask in `noiseForValue` to correctly extract bytes

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432e294cc88320ae7318095cd0d7b4